### PR TITLE
fix: Correção de acessibilidade

### DIFF
--- a/livros QA/livros.md
+++ b/livros QA/livros.md
@@ -1,41 +1,41 @@
 # Livros para QAs do zero ao avançado
 
-| Nome                                                                                                                     | Link                         |
-| ------------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
-| Jornada ágil de Qualidade                                                                                                | [📚](https://amzn.to/3WOTA7S) |
-| Engenharia de software                                                                                                   | [📚](https://amzn.to/3Gl8UUi) |
-| Qualidade de Software na Pratica                                                                                         | [📚](https://amzn.to/3vhNO2R) |
-| Metricas Ágeis: Obtenha Melhores Resultados Em Sua Equipe                                                                | [📚](https://amzn.to/3WvGfBB) |
-| Base de Conhecimento em Teste de Software                                                                                | [📚](https://amzn.to/3vk1r1h) |
-| Engenharia de Software Moderna                                                                                           | [📚](https://amzn.to/3GndMYO) |
-| The Art of Software Testing                                                                                              | [📚](https://amzn.to/3PV57jJ) |
-| Implementando o Desenvolvimento Lean de Software: Do Conceito ao Dinheiro                                                | [📚](https://amzn.to/3GmHvBe) |
-| Desenvolvimento de software - orientando a objetos                                                                       | [📚](https://amzn.to/3Gl9ZeO) |
-| Análise De Riscos Em Projetos De Teste De Software                                                                       | [📚](https://amzn.to/3VvLWy1) |
-| Testes de software: Produzindo sistemas melhores e mais confiáveis                                                       | [📚](https://amzn.to/3VmYaJi) |
-| Refatoração: Aperfeiçoando o Design de Códigos Existentes                                                                | [📚](https://amzn.to/3WQx3qW) |
-| Desenvolvimento de Software com Scrum: Aplicando Métodos Ágeis com Sucesso                                               | [📚](https://amzn.to/3I7Vc8C) |
-| Agile Testing: A Practical Guide for Testers and Agile Teams (Addison-Wesley Signature Series (Cohn))                    | [📚](https://amzn.to/3Ib9HIC) |
-| Hands-On Mobile App Testing: A Guide for Mobile Testers and Anyone Involved in the Mobile App Business (English Edition) | [📚](https://amzn.to/3Gogn51) |
-| The Complete Software Tester: Concepts, Skills, and Strategies for High-Quality Testing (English Edition)                | [📚](https://amzn.to/3FWg2Vz) |
-| Effective Software Testing: A Developer's Guide                                                                          | [📚](https://amzn.to/3FWgaEx) |
-| O mítico homem-mês: ensaios sobre engenharia de software                                                                 | [📚](https://amzn.to/3I8SCPK) |
-| Domain-Driven Design: Atacando as complexidades no coração do software                                                   | [📚](https://amzn.to/3WLvYku) |
-| Código limpo: Habilidades práticas do Agile Software                                                                     | [📚](https://amzn.to/3PUUFIV) |
-| O projeto fênix – Edição comemorativa: um romance sobre TI, DevOps e sobre ajudar o seu negócio a vencer                 | [📚](https://amzn.to/3C6Jffu) |
-| Arquitetura limpa: O guia do artesão para estrutura e design de software                                                 | [📚](https://amzn.to/3VvLFuZ) |
-| Manual de DevOps: como obter agilidade, confiabilidade e segurança em organizações tecnológicas                          | [📚](https://amzn.to/3WRXTzf) |
-| Accelerate: The Science of Lean Software and DevOps: Building and Scaling High Performing Technology Organizations       | [📚](https://amzn.to/3G2tibg) |
-| DevOps na prática: Entrega de software confiável e automatizada                                                          | [📚](https://amzn.to/3YUNtAM) |
-| DevOps para leigos: os primeiros passos para o sucesso                                                                   | [📚](https://amzn.to/3PZGget) |
-| Lessons Learned in Software Testing: A Context-Driven Approach                                                           | [📚](https://amzn.to/3VmYK9W) |
-| Agile Testing Condensed: A Brief Introduction (English Edition)                                                          | [📚](https://amzn.to/3YXmSmn) |
-| The Future of Software Quality Assurance (English Edition)                                                               | [📚](https://amzn.to/3vk1x99) |
-| Agile Software Testing: A Practical Guide (Essential Book 9) (English Edition)                                           | [📚](https://amzn.to/3YWjVCA) |
-| QA Quality Assurance & Software Testing Fundamentals (English Edition)                                                   | [📚](https://amzn.to/3C8EKBc) |
-| More Agile Testing: Learning Journeys for the Whole Team (Addison-Wesley Signature Series (Cohn)) (English Edition)      | [📚](https://amzn.to/3YSP8Xr) |
-| Como ser um Programador Melhor: um Manual Para Programadores que se Importam com Código                                  | [📚](https://amzn.to/3GmHSvC) |
-| Tdd - Test Driven Development na Pratica                                                                                 | [📚](https://amzn.to/3GnGetL) |
-| Testes automatizados de software: Um guia prático                                                                        | [📚](https://amzn.to/3WEwIYy) |
-| BDD in Action: Behavior-Driven Development for the whole software lifecycle (English Edition)                            | [📚](https://amzn.to/3I8NwCW) |
-| Specification by Example: How Successful Teams Deliver the Right Software                            | [📚](https://amzn.to/3NVCeDd) |
+| Nome                                                                                                                     |
+|--------------------------------------------------------------------------------------------------------------------------|
+| [Jornada ágil de Qualidade                                                                    ](https://amzn.to/3WOTA7S) |
+| [Engenharia de software                                                                                                  ](https://amzn.to/3Gl8UUi) |
+| [Qualidade de Software na Pratica                                                                                        ](https://amzn.to/3vhNO2R) |
+| [Metricas Ágeis: Obtenha Melhores Resultados Em Sua Equipe                                                               ](https://amzn.to/3WvGfBB) |
+| [Base de Conhecimento em Teste de Software                                                                               ](https://amzn.to/3vk1r1h) |
+| [Engenharia de Software Moderna                                                                                          ](https://amzn.to/3GndMYO) |
+| [The Art of Software Testing                                                                                             ](https://amzn.to/3PV57jJ) |
+| [Implementando o Desenvolvimento Lean de Software: Do Conceito ao Dinheiro                                               ](https://amzn.to/3GmHvBe) |
+| [Desenvolvimento de software - orientando a objetos                                                                      ](https://amzn.to/3Gl9ZeO) |
+| [Análise De Riscos Em Projetos De Teste De Software                                                                      ](https://amzn.to/3VvLWy1) |
+| [Testes de software: Produzindo sistemas melhores e mais confiáveis                                                      ](https://amzn.to/3VmYaJi) |
+| [Refatoração: Aperfeiçoando o Design de Códigos Existentes                                                               ](https://amzn.to/3WQx3qW) |
+| [Desenvolvimento de Software com Scrum: Aplicando Métodos Ágeis com Sucesso                                              ](https://amzn.to/3I7Vc8C) |
+| [Agile Testing: A Practical Guide for Testers and Agile Teams (Addison-Wesley Signature Series (Cohn))                   ](https://amzn.to/3Ib9HIC) |
+| [Hands-On Mobile App Testing: A Guide for Mobile Testers and Anyone Involved in the Mobile App Business (English Edition)](https://amzn.to/3Gogn51) |
+| [The Complete Software Tester: Concepts, Skills, and Strategies for High-Quality Testing (English Edition)               ](https://amzn.to/3FWg2Vz) |
+| [Effective Software Testing: A Developer's Guide                                                                         ](https://amzn.to/3FWgaEx) |
+| [O mítico homem-mês: ensaios sobre engenharia de software                                                                ](https://amzn.to/3I8SCPK) |
+| [Domain-Driven Design: Atacando as complexidades no coração do software                                                  ](https://amzn.to/3WLvYku) |
+| [Código limpo: Habilidades práticas do Agile Software                                                                    ](https://amzn.to/3PUUFIV) |
+| [O projeto fênix – Edição comemorativa: um romance sobre TI, DevOps e sobre ajudar o seu negócio a vencer                ](https://amzn.to/3C6Jffu) |
+| [Arquitetura limpa: O guia do artesão para estrutura e design de software                                                ](https://amzn.to/3VvLFuZ) |
+| [Manual de DevOps: como obter agilidade, confiabilidade e segurança em organizações tecnológicas                         ](https://amzn.to/3WRXTzf) |
+| [Accelerate: The Science of Lean Software and DevOps: Building and Scaling High Performing Technology Organizations      ](https://amzn.to/3G2tibg) |
+| [DevOps na prática: Entrega de software confiável e automatizada                                                         ](https://amzn.to/3YUNtAM) |
+| [DevOps para leigos: os primeiros passos para o sucesso                                                                  ](https://amzn.to/3PZGget) |
+| [Lessons Learned in Software Testing: A Context-Driven Approach                                                          ](https://amzn.to/3VmYK9W) |
+| [Agile Testing Condensed: A Brief Introduction (English Edition)                                                         ](https://amzn.to/3YXmSmn) |
+| [The Future of Software Quality Assurance (English Edition)                                                              ](https://amzn.to/3vk1x99) |
+| [Agile Software Testing: A Practical Guide (Essential Book 9) (English Edition)                                          ](https://amzn.to/3YWjVCA) |
+| [QA Quality Assurance & Software Testing Fundamentals (English Edition)                                                  ](https://amzn.to/3C8EKBc) |
+| [More Agile Testing: Learning Journeys for the Whole Team (Addison-Wesley Signature Series (Cohn)) (English Edition)     ](https://amzn.to/3YSP8Xr) |
+| [Como ser um Programador Melhor: um Manual Para Programadores que se Importam com Código                                 ](https://amzn.to/3GmHSvC) |
+| [Tdd - Test Driven Development na Pratica                                                                                ](https://amzn.to/3GnGetL) |
+| [Testes automatizados de software: Um guia prático                                                                       ](https://amzn.to/3WEwIYy) |
+| [BDD in Action: Behavior-Driven Development for the whole software lifecycle (English Edition)                           ](https://amzn.to/3I8NwCW) |
+| [Specification by Example: How Successful Teams Deliver the Right Software                                               ](https://amzn.to/3NVCeDd) |


### PR DESCRIPTION
# O que esse PR propõe?

O uso de ícones para links não é uma boa prática, devido o modo de leitura dos leitores de tela.

A título de curiosidade o NVDA (leitor de tela) iria ler da seguinte forma. 

> Link coluna 2 Link Books.

## Proposta de correção

Uma das soluções mais interessante é retirar a coluna de Link e inserir o link no nome do livro.
Dessa forma, o link fica contextual e muito mais claro e objetivo.